### PR TITLE
Make the illuminance attribute nullable.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -107,7 +107,7 @@ The AmbientLightSensor Interface {#ambient-light-sensor-interface}
 <pre class="idl">
   [Constructor(optional SensorOptions sensorOptions)]
   interface AmbientLightSensor : Sensor {
-    readonly attribute unrestricted double illuminance;
+    readonly attribute unrestricted double illuminance?;
   };
 </pre>
 


### PR DESCRIPTION
Closes #25


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/ambient-light/fix-25.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/ambient-light/f95cfcc...bcbc53c.html)