### PR TITLE
Typo fix

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -292,7 +292,7 @@ Use Cases and Requirements {#usecases-requirements}
 
 - A Web application provides input for a smart home system to control lighting.
 - A Web aplication checks whether light level at work space is sufficient.
-- A Web application calculates settings for a camera with manual controls (apperture, shutter speed, ISO).
+- A Web application calculates settings for a camera with manual controls (aperture, shutter speed, ISO).
 - A Web application monitors light level changes produced by hovering hand user gesture and
   interprets them to control a game character.
 


### PR DESCRIPTION
apperture → aperture


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tomayac/ambient-light/pull/62.html" title="Last updated on Jul 7, 2020, 2:02 PM UTC (a986aa5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ambient-light/62/e08f3f9...tomayac:a986aa5.html" title="Last updated on Jul 7, 2020, 2:02 PM UTC (a986aa5)">Diff</a>