### PR TITLE
Remove custom biblio entry for MEDIAQUERIES-5.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -59,24 +59,6 @@ urlPrefix: https://www.w3.org/TR/permissions/; spec: PERMISSIONS
   type: dfn
     text: name; url: dfn-name
 </pre>
-<pre class=biblio>
-{
-	"MEDIAQUERIES-5": {
-		"authors": [
-            "Dean Jackson",
-			"Florian Rivoal",
-			"Tab Atkins"
-		],
-		"href": "https://drafts.csswg.org/mediaqueries-5/",
-		"title": "Media Queries Level 5",
-		"status": "ED",
-		"publisher": "W3C",
-		"deliveredBy": [
-			"https://www.w3.org/Style/CSS/members"
-		]
-	}
-}
-</pre>
 
 Introduction {#intro}
 ============


### PR DESCRIPTION
This was added back in #46 and the reasoning is not entirely clear to me:
the CSSOM reference is also to an Editorial Draft and did not need a local
biblio entry.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/ambient-light/pull/72.html" title="Last updated on Dec 7, 2021, 12:53 PM UTC (62aa62c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ambient-light/72/1c97c3e...rakuco:62aa62c.html" title="Last updated on Dec 7, 2021, 12:53 PM UTC (62aa62c)">Diff</a>