### PR TITLE
Remove a few custom GENERIC-SENSORS anchors that are exported by the spec.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -37,20 +37,16 @@ Default Biblio Status: current
 urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
   type: dfn
     text: high-level
-    text: default sensor
     text: implementation specific; url: implementation-specific
     text: reporting mode; url: reporting-modes
     text: auto
     text: construct a sensor object; url: construct-sensor-object
-    text: initialize a sensor object; url: initialize-a-sensor-object
     text: limit maximum sampling frequency; url: limit-max-frequency
     text: reduce accuracy; url: reduce-accuracy
     text: mitigation strategies; url: mitigation-strategies
     text: sampling frequency
     text: sensor type
     text: sensor reading
-    text: check sensor policy-controlled features; url: check-sensor-policy-controlled-features
-    text: sensor permission name; url: sensor-permission-names
     text: automation
     text: mock sensor type
     text: MockSensorType


### PR DESCRIPTION
Reduce duplication by eliminating some definitions that are exported by the
Generic Sensor spec itself.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/ambient-light/pull/73.html" title="Last updated on Dec 7, 2021, 1:28 PM UTC (153f358)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ambient-light/73/1c97c3e...rakuco:153f358.html" title="Last updated on Dec 7, 2021, 1:28 PM UTC (153f358)">Diff</a>