### PR TITLE
Use [=powerful feature/name=] dfn instead of custom

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -55,9 +55,6 @@ urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
     text: mock sensor type
     text: MockSensorType
     text: mock sensor reading values
-urlPrefix: https://www.w3.org/TR/permissions/; spec: PERMISSIONS
-  type: dfn
-    text: name; url: dfn-name
 </pre>
 
 Introduction {#intro}
@@ -208,7 +205,7 @@ The <a>Ambient Light Sensor</a> has a <a>default sensor</a>,
 which is the device's main light detector.
 
 The <a>Ambient Light Sensor</a> is a [=powerful feature=] that is identified by the
-[=name=] "ambient-light-sensor", which is also its associated
+[=powerful feature/name=] "ambient-light-sensor", which is also its associated
 [=sensor permission name=]. Its [=powerful feature/permission revocation algorithm=] is the
 result of calling the [=generic sensor permission revocation algorithm=] with
 "ambient-light-sensor".


### PR DESCRIPTION
This reverts commit 6617c2476293d2ec7952210470dc9a32c15f7725.

The dfn is now in the spec-data proper.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ambient-light/pull/74.html" title="Last updated on Dec 7, 2021, 2:54 PM UTC (9ac516e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ambient-light/74/a5846b9...9ac516e.html" title="Last updated on Dec 7, 2021, 2:54 PM UTC (9ac516e)">Diff</a>