### PR TITLE
editorial: Use Web IDL's definition conventions for getters.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -237,9 +237,11 @@ To construct an {{AmbientLightSensor}} object the user agent must invoke the
 
 ### The illuminance attribute ### {#ambient-light-sensor-reading-attribute}
 
-The <a attribute for="AmbientLightSensor">illuminance</a> attribute of the {{AmbientLightSensor}}
-interface represents the [=current light level=] and returns the result of invoking
-[=get value from latest reading=] with `this` and "illuminance" as arguments.
+The {{AmbientLightSensor/illuminance}} getter steps are:
+
+1. Let |illuminance| be the result of invoking [=get value from latest
+   reading=] with [=this=] and "illuminance" as arguments.
+1. Return |illuminance|.
 
 Abstract Operations {#abstract-operations}
 ===================


### PR DESCRIPTION
Aligns with whatwg/webidl#882 and uses the format "The _attr_ getter steps
are [...]".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/ambient-light/pull/78.html" title="Last updated on May 27, 2022, 2:58 PM UTC (f537496)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ambient-light/78/b91297a...rakuco:f537496.html" title="Last updated on May 27, 2022, 2:58 PM UTC (f537496)">Diff</a>