### PR TITLE
Fix use cases typo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -440,7 +440,7 @@ Use Cases and Requirements {#usecases-requirements}
 =========
 
 - A Web application provides input for a smart home system to control lighting.
-- A Web aplication checks whether light level at work space is sufficient.
+- A Web application checks whether light level at work space is sufficient.
 - A Web application calculates settings for a camera with manual controls (aperture, shutter speed, ISO).
 - A Web application checks the current light level to determine whether a
   camera stream will contain data that is accurate enough for its purposes


### PR DESCRIPTION
This drive-by typo fix was triggered by this line being quoted in https://github.com/w3c/ambient-light/issues/79#issuecomment-1231870047 -- interesting way to catch a typo?

@rakuco PTAL


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ambient-light/pull/81.html" title="Last updated on Aug 31, 2022, 3:28 PM UTC (cb0ec37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ambient-light/81/2fbaa74...cb0ec37.html" title="Last updated on Aug 31, 2022, 3:28 PM UTC (cb0ec37)">Diff</a>