### PR TITLE
Define and export "ambient-light-sensor" permission

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -292,10 +292,11 @@ subclass is the {{AmbientLightSensor}} class.
 The <a>Ambient Light Sensor</a> has a <a>default sensor</a>,
 which is the device's main light detector.
 
-The <a>Ambient Light Sensor</a> is a [=powerful feature=] that is identified by the
-[=powerful feature/name=] "ambient-light-sensor", which is also its associated
-[=sensor permission name=]. Its [=powerful feature/permission revocation algorithm=] is the
-result of calling the [=generic sensor permission revocation algorithm=] with
+The <a>Ambient Light Sensor</a> is a [=powerful feature=] that is identified by
+the [=powerful feature/name=] "<dfn permission export>ambient-light-sensor</dfn>",
+which is also its associated [=sensor permission name=]. Its
+[=powerful feature/permission revocation algorithm=] is the result of calling
+the [=generic sensor permission revocation algorithm=] with
 "ambient-light-sensor".
 
 The <a>Ambient Light Sensor</a> is a [=policy-controlled feature=] identified by the string "ambient-light-sensor". Its [=default allowlist=] is `'self'`.


### PR DESCRIPTION
So we can link to it eventually in https://w3c.github.io/permissions-registry/


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/ambient-light/pull/82.html" title="Last updated on Oct 18, 2022, 12:58 AM UTC (96e2747)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ambient-light/82/8983c22...miketaylr:96e2747.html" title="Last updated on Oct 18, 2022, 12:58 AM UTC (96e2747)">Diff</a>