### PR TITLE
editorial: Remove "sensor reading" custom anchor.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -44,7 +44,6 @@ urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
     text: mitigation strategies; url: mitigation-strategies
     text: sampling frequency
     text: sensor type
-    text: sensor reading
     text: automation
     text: mock sensor type
     text: MockSensorType


### PR DESCRIPTION
w3c/sensors#456 started exporting the definition, so there is no need to
have a custom anchor anymore.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/ambient-light/pull/84.html" title="Last updated on Jan 30, 2023, 10:25 AM UTC (ec89516)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ambient-light/84/2f4a4e2...rakuco:ec89516.html" title="Last updated on Jan 30, 2023, 10:25 AM UTC (ec89516)">Diff</a>