### PR TITLE
Fix comparison of rounded readings in threshold check algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -48,8 +48,6 @@ urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
     text: mock sensor type
     text: MockSensorType
     text: mock sensor reading values
-    text: threshold check algorithm
-    text: reading quantization algorithm
     text: latest reading
 urlPrefix: https://tc39.es/ecma262/; spec: ECMA-262
   type: abstract-op
@@ -384,12 +382,12 @@ check algorithm=]:
   1. Let |latestIlluminance| be |latestReading|["illuminance"].
   1. If [$abs$](|latestIlluminance| - |newIlluminance|) < [=illuminance
      threshold value=], return false.
-  1. Let |roundedNewIlluminance| be the result of invoking the [=ambient light
+  1. Let |roundedNewReading| be the result of invoking the [=ambient light
      reading quantization algorithm=] algorithm with |newIlluminance|.
-  1. Let |roundedLatestIlluminance| be the result of invoking the [=ambient
+  1. Let |roundedLatestReading| be the result of invoking the [=ambient
      light reading quantization algorithm=] algorithm with |latestIlluminance|.
-  1. If |roundedNewIlluminance| and |roundedLatestIlluminance| are equal,
-     return false.
+  1. If |roundedNewReading|["illuminance"] and |roundedLatestIlluminance|["illuminance"]
+     are equal, return false.
   1. Otherwise, return true.
 </div>
 


### PR DESCRIPTION
The ambient light reading quantization algorithm returns an entire reading,
not an illuminance, so account for that properly in the threshold check
algorithm.

While here, remove custom anchors for some definitions that are exported by
the Generic Sensor spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/ambient-light/pull/85.html" title="Last updated on Jul 21, 2023, 7:57 AM UTC (456c5b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ambient-light/85/5e43a98...rakuco:456c5b0.html" title="Last updated on Jul 21, 2023, 7:57 AM UTC (456c5b0)">Diff</a>