### PR TITLE
Rewrite Automation section after w3c/sensors#470

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -44,10 +44,6 @@ urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
     text: mitigation strategies; url: mitigation-strategies
     text: sampling frequency
     text: sensor type
-    text: automation
-    text: mock sensor type
-    text: MockSensorType
-    text: mock sensor reading values
     text: latest reading
 urlPrefix: https://tc39.es/ecma262/; spec: ECMA-262
   type: abstract-op
@@ -417,22 +413,17 @@ quantization algorithm=]:
 
 Automation {#automation}
 ==========
-This section extends the [=automation=] section defined in the Generic Sensor API [[GENERIC-SENSOR]]
-to provide mocking information about the ambient light levels for the purposes of testing a user agent's
-implementation of [=Ambient Light Sensor=].
+This section extends [[GENERIC-SENSOR#automation]] by providing [=Ambient Light Sensor=]-specific virtual sensor metadata.
 
+<div algorithm>
+The <dfn>illuminance reading parsing algorithm</dfn>, given a JSON {{Object}} |parameters|, must return the result of invoking [=parse single-value number reading=] with |parameters| and "`illuminance`".
+</div>
 
-<h3 id="mock-ambient-light-sensor-type">Mock Sensor Type</h3>
-
-The {{AmbientLightSensor}} class has an associated [=mock sensor type=] which is
-<a for="MockSensorType" enum-value>"ambient-light"</a>, its [=mock sensor reading values=]
-dictionary is defined as follows:
-
-<pre class="idl">
-  dictionary AmbientLightReadingValues {
-    required double? illuminance;
-  };
-</pre>
+The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
+: [=map/key=]
+:: "`ambient-light`"
+: [=map/value=]
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Ambient Light Sensor=] and [=reading parsing algorithm=] is [=illuminance reading parsing algorithm=].
 
 Use Cases and Requirements {#usecases-requirements}
 =========

--- a/index.bs
+++ b/index.bs
@@ -413,6 +413,7 @@ quantization algorithm=]:
 
 Automation {#automation}
 ==========
+
 This section extends [[GENERIC-SENSOR#automation]] by providing [=Ambient Light Sensor=]-specific virtual sensor metadata.
 
 <div algorithm>


### PR DESCRIPTION
The Automation section in the Generic Sensor API specification was rewritten and several terms and concepts have changed.

This commit adapts the Ambient Light Sensor spec to the changes:
* Remove references to "mock sensor type", "mock sensor reading values" and the "MockSensorType" enum.
* Define an entry in the per-type virtual sensor metadata map whose key is what used to be the "ambient-light" entry in MockSensorType and an appropriate virtual sensor metadata entry.

This is enough to integrate properly with the Generic Sensor spec and allow Ambient Light virtual sensors to be created and used.

Fixes #86.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JuhaVainio/ambient-light/pull/87.html" title="Last updated on Oct 20, 2023, 11:19 AM UTC (7bbbbfa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ambient-light/87/adf6c8b...JuhaVainio:7bbbbfa.html" title="Last updated on Oct 20, 2023, 11:19 AM UTC (7bbbbfa)">Diff</a>