### PR TITLE
Adapt to virtual sensor changes in w3c/sensors#475

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -294,6 +294,8 @@ the [=generic sensor permission revocation algorithm=] with
 
 The <a>Ambient Light Sensor</a> is a [=policy-controlled feature=] identified by the string "ambient-light-sensor". Its [=default allowlist=] is `'self'`.
 
+The <a>Ambient Light Sensor</a> has a [=virtual sensor type=], which is "<code><dfn data-lt="ambient-light virtual sensor type">ambient-light</dfn></code>".
+
 The <dfn>current light level</dfn> or <dfn>illuminance</dfn>
 is a value that represents the ambient light level
 around the hosting device. Its unit is the lux (lx) [[SI]].
@@ -422,9 +424,9 @@ The <dfn>illuminance reading parsing algorithm</dfn>, given a JSON {{Object}} |p
 
 The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
 : [=map/key=]
-:: "`ambient-light`"
+:: "<code>[=ambient-light virtual sensor type|ambient-light=]</code>"
 : [=map/value=]
-:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Ambient Light Sensor=] and [=reading parsing algorithm=] is [=illuminance reading parsing algorithm=].
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/reading parsing algorithm=] is [=illuminance reading parsing algorithm=].
 
 Use Cases and Requirements {#usecases-requirements}
 =========


### PR DESCRIPTION
The PR above removed the "virtual sensor type" item from the "virtual sensor
metadata" struct and turned it into a string that is referenced from the
automation bits as well as (optionally) defined by a sensor type.

Adapt to it here by removing mentions of `[=virtual sensor metadata/virtual
sensor type=]` from the spec and adding virtual sensor types to each sensor
type defined here.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/ambient-light/pull/88.html" title="Last updated on Nov 22, 2023, 4:00 PM UTC (b75a064)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ambient-light/88/2f5cf3f...rakuco:b75a064.html" title="Last updated on Nov 22, 2023, 4:00 PM UTC (b75a064)">Diff</a>