### PR TITLE
Add SotD implementation status advisement

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13,7 +13,14 @@ Group: dap
 Abstract:
   This specification defines a concrete sensor interface to monitor
   the ambient light level or illuminance of the device's environment.
-Status Text:
+Status Text: <div class="advisement">
+  This API is not enabled by default in any browser engine.
+  In Blink, it requires enabling a feature flag.
+  To mitigate fingerprinting risk, the API returns integer-only illuminance values.
+  Implementer standards positions:
+  <a href="https://github.com/mozilla/standards-positions/issues/35">Mozilla</a>.
+  No WebKit standards position has been filed.
+  </div>
   The Devices and Sensors Working Group is pursuing modern security and privacy
   reviews for this specification in consideration of the amount of change in both
   this specification and in privacy and security review practices since the
@@ -22,6 +29,7 @@ Status Text:
   on 3 October 2017</a>. Similarly, the group is pursuing an update to the Technical
   Architecture Group review for this specification to account for the latest
   architectural review practices.
+
 Version History: https://github.com/w3c/ambient-light/commits/main/index.bs
 Indent: 2
 Repository: w3c/ambient-light


### PR DESCRIPTION
Adds a `.advisement` box to the Status of This Document section to signal implementation status to developers at a glance.

Per TAG requirement ([w3ctag/design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-3889788860)):

> At a minimum, each document's support level should be in its SotD section, but ideally the WG would find a way to ensure that developers reading a specification can tell at a glance which kind of document they're reading.

All implementation status claims are verified against MDN BCD. Standards position URLs are verified against the live issues.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/ambient-light/pull/92.html" title="Last updated on Mar 31, 2026, 4:55 AM UTC (0d0c7e0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ambient-light/92/bcd9e16...marcoscaceres:0d0c7e0.html" title="Last updated on Mar 31, 2026, 4:55 AM UTC (0d0c7e0)">Diff</a>