### PR TITLE
Add implementation status note to SotD

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -14,6 +14,8 @@ Abstract:
   This specification defines a concrete sensor interface to monitor
   the ambient light level or illuminance of the device's environment.
 Status Text:
+  <p class="advisement">This specification is not available by default in any browser engine.
+  It is not expected to advance to W3C Recommendation in its current form.</p>
   The Devices and Sensors Working Group is pursuing modern security and privacy
   reviews for this specification in consideration of the amount of change in both
   this specification and in privacy and security review practices since the


### PR DESCRIPTION
Addresses the TAG's 'at a glance' concern in design-reviews#1187.

The paragraph uses `<p class="advisement">` so it renders as a highlighted box, making the implementation-status signal visible at a glance rather than blending into the SotD boilerplate.

Reviewed in fork by @marcoscaceres and @jyasskin: https://github.com/christianliebel/ambient-light/pull/1


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/christianliebel/ambient-light/pull/93.html" title="Last updated on May 14, 2026, 11:48 AM UTC (1c80664)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ambient-light/93/bcd9e16...christianliebel:1c80664.html" title="Last updated on May 14, 2026, 11:48 AM UTC (1c80664)">Diff</a>